### PR TITLE
Added package.json description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name" : "generator-marionette",
+  "description": "Yeoman generator for Express, Marionette and Backbone with AMD",
   "version" : "0.1.0",
   "keywords": [
     "yeoman-generator",


### PR DESCRIPTION
Currently, npmjs.org shows the first line of the README which includes MarkDown syntax. Also, the description is displayed in the community generators list at http://yeoman.io/community-generators.html.
