### PR TITLE
Fixes the templates and grunt-contrib-handlebars so compilation works.

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -169,6 +169,15 @@ module.exports = function (grunt) {
                     useStrict: true,
                     wrap: true,
                     //uglify2: {} // https://github.com/mishoo/UglifyJS2
+                    pragmasOnSave: {
+                        //removes Handlebars.Parser code (used to compile template strings) set
+                        //it to `false` if you need to parse template strings even after build
+                        excludeHbsParser : true,
+                        // kills the entire plugin set once it's built.
+                        excludeHbs: true,
+                        // removes i18n precompiler, handlebars and json2
+                        excludeAfterBuild: true
+                    }
                 }
             }
         },
@@ -263,7 +272,7 @@ module.exports = function (grunt) {
                     amd: true
                 },
                 files: {
-                    '.tmp/scripts/templates.js': ['<%= yeoman.app %>/scripts/templates/*.hbs']
+                    '.tmp/scripts/templates.js': ['<%= yeoman.app %>templates/**/*.hbs']
                 }
             }
         }

--- a/templates/javascript/compositeview.js
+++ b/templates/javascript/compositeview.js
@@ -16,10 +16,7 @@ function( <%= _.classify('backbone')%><% if (!_.isEmpty(itemview)) { %>, <%=_.cl
 		<% if (!_.isEmpty(itemview)) { %>
     	itemView: <%= _.classify(itemview) %>,<% } %>
     	<% if (!_.isEmpty(compTmpl)) { %>
-    	template: {
-			type: 'handlebars',
-			template: <%= _.classify(compTmpl) %>
-		},
+    	template: <%= _.classify(compTmpl) %>,
     	<% } %>
 
     	/* ui selector cache */

--- a/templates/javascript/itemview.js
+++ b/templates/javascript/itemview.js
@@ -13,10 +13,8 @@ function( <%= _.classify('backbone') %><% if (!_.isEmpty(tmpl)) { %>, <%= _.clas
 			console.log("initialize a <%= _.classify(name) %> ItemView");
 		},
 		<% if (!_.isEmpty(tmpl)) { %>
-    	template: {
-			type: 'handlebars',
-			template: <%= _.classify(tmpl) %>
-		},<% } %>
+    	template: <%= _.classify(tmpl) %>,
+        <% } %>
 
     	/* ui selector cache */
     	ui: {},

--- a/templates/javascript/layout.js
+++ b/templates/javascript/layout.js
@@ -13,10 +13,7 @@ function( <%= _.classify('backbone') %><% if (!_.isEmpty(tmpl)) { %>, <%= _.clas
 			console.log("initialize a <%= _.classify(name) %> Layout");
 		},
 		<% if (!_.isEmpty(tmpl)) { %>
-    	template: {
-			type: 'handlebars',
-			template: <%= _.classify(tmpl) %>
-		},
+    	template: <%= _.classify(tmpl) %>,
     	<% } %>
 
     	/* Layout sub regions */


### PR DESCRIPTION
The templates weren't getting compiled at all with `grunt build`. The path to them was wrong. 

Once that was fixed them Backbone wasn't able to find the templates because of the way the `template` property was set.
