### PR TITLE
add time-grunt

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -14,6 +14,8 @@ var mountFolder = function (connect, dir) {
 module.exports = function (grunt) {
     // load all grunt tasks
     require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+    // show elapsed time at the end
+    require('time-grunt')(grunt);
 
     // configurable paths
     var yeomanConfig = {

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -38,7 +38,8 @@
     "matchdep": "~0.1.2",
     "mocha-phantomjs": "~3.1.0",
     "grunt-exec": "~0.4.2",
-    "grunt-contrib-watch": "~0.4.4"
+    "grunt-contrib-watch": "~0.4.4",
+    "time-grunt": "~0.1.1"
   },
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
[time-grunt](https://github.com/sindresorhus/time-grunt) displays the elapsed execution time of grunt tasks. We're using it in [generator-webapp](https://github.com/yeoman/generator-webapp/blob/master/app/templates/Gruntfile.js#L11-L12).
