### PR TITLE
Correct spelling of --create-all flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The biggest change in this release is the automatic unit test generation as part
 
 Recommends
 -----------------
-The generator is most useful using the --creat-all flag. In the example:
+The generator is most useful using the --create-all flag. In the example:
 
     $ yo marionette:compositeview peopleview --itemview personview --create-all
 


### PR DESCRIPTION
A very trivial fix. I noticed a spelling mistake with one of the flags within the Recommends section.  This fix corrects that mistake.
